### PR TITLE
feat(agendamento): expõe endpoints REST para gerenciamento de agendam…

### DIFF
--- a/matheusmacielapi.postman_collection.json
+++ b/matheusmacielapi.postman_collection.json
@@ -570,6 +570,139 @@
 					"response": []
 				}
 			]
+		},
+		{
+			"name": "module",
+			"item": [
+				{
+					"name": "agendamento",
+					"item": [
+						{
+							"name": "agendar",
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"idMorador\": 1,\n    \"idRecurso\": 1,\n    \"dataAgendamento\": \"2025-10-25\"\n}\n\n// Tentar Criar um Agendamento em Data Passada (Erro)\n/*{\n    \"idMorador\": 2,\n    \"idRecurso\": 2,\n    \"dataAgendamento\": \"2025-09-10\"\n}*/\n\n//Agendamento em Data já ocupada (exceção)\n/*{\n    \"idMorador\": 3,\n    \"idRecurso\": 1,\n    \"dataAgendamento\": \"2025-10-25\"\n}*/",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{baseUrl}}/api/agendamentos",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"api",
+										"agendamentos"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "atualizar",
+							"request": {
+								"auth": {
+									"type": "noauth"
+								},
+								"method": "PUT",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "\"2025-11-05\"",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{baseUrl}}/api/agendamentos/1",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"api",
+										"agendamentos",
+										"1"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Listar Todos",
+							"request": {
+								"auth": {
+									"type": "noauth"
+								},
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{baseUrl}}/api/agendamentos",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"api",
+										"agendamentos"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "obter por Id",
+							"request": {
+								"auth": {
+									"type": "noauth"
+								},
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{baseUrl}}/api/agendamentos/1",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"api",
+										"agendamentos",
+										"1"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "deletar",
+							"request": {
+								"auth": {
+									"type": "noauth"
+								},
+								"method": "DELETE",
+								"header": [],
+								"url": {
+									"raw": "{{baseUrl}}/api/agendamentos/1",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"api",
+										"agendamentos",
+										"1"
+									]
+								}
+							},
+							"response": []
+						}
+					]
+				}
+			]
 		}
 	]
 }

--- a/src/main/java/br/edu/infnet/matheusmacielapi/module/agendamento/controller/AgendamentoController.java
+++ b/src/main/java/br/edu/infnet/matheusmacielapi/module/agendamento/controller/AgendamentoController.java
@@ -1,0 +1,60 @@
+package br.edu.infnet.matheusmacielapi.module.agendamento.controller;
+
+import br.edu.infnet.matheusmacielapi.module.agendamento.domain.Agendamento;
+import br.edu.infnet.matheusmacielapi.module.agendamento.dto.AgendamentoRequestDTO;
+import br.edu.infnet.matheusmacielapi.module.agendamento.service.AgendamentoService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+
+import java.net.URI;
+import java.time.LocalDate;
+import java.util.Collection;
+
+@RestController
+@RequestMapping("/api/agendamentos")
+public class AgendamentoController {
+
+    private final AgendamentoService agendamentoService;
+
+    public AgendamentoController(AgendamentoService agendamentoService) {
+        this.agendamentoService = agendamentoService;
+    }
+
+    @GetMapping
+    public ResponseEntity<Collection<Agendamento>> listarTodos() {
+        return ResponseEntity.ok(agendamentoService.listarTodos());
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<Agendamento> buscarPorId(@PathVariable Long id) {
+        Agendamento agendamento = agendamentoService.buscarPorId(id);
+        return ResponseEntity.ok(agendamento);
+    }
+
+    @PostMapping
+    public ResponseEntity<Agendamento> agendar(@RequestBody AgendamentoRequestDTO agendamentoDTO) {
+        Agendamento novoAgendamento = agendamentoService.agendar(
+                agendamentoDTO.getIdMorador(),
+                agendamentoDTO.getIdRecurso(),
+                agendamentoDTO.getDataAgendamento()
+        );
+
+        URI uri = ServletUriComponentsBuilder.fromCurrentRequest().path("/{id}")
+                .buildAndExpand(novoAgendamento.getId()).toUri();
+
+        return ResponseEntity.created(uri).body(novoAgendamento);
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<Agendamento> atualizar(@PathVariable Long id, @RequestBody LocalDate novaData) {
+        Agendamento agendamentoAtualizado = agendamentoService.atualizar(id, novaData);
+        return ResponseEntity.ok(agendamentoAtualizado);
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> cancelar(@PathVariable Long id) {
+        agendamentoService.cancelar(id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/br/edu/infnet/matheusmacielapi/module/agendamento/dto/AgendamentoRequestDTO.java
+++ b/src/main/java/br/edu/infnet/matheusmacielapi/module/agendamento/dto/AgendamentoRequestDTO.java
@@ -1,0 +1,29 @@
+package br.edu.infnet.matheusmacielapi.module.agendamento.dto;
+
+import java.time.LocalDate;
+
+public class AgendamentoRequestDTO {
+
+    private Long idMorador;
+    private Long idRecurso;
+    private LocalDate dataAgendamento;
+
+    public Long getIdMorador() {
+        return idMorador;
+    }
+    public void setIdMorador(Long idMorador) {
+        this.idMorador = idMorador;
+    }
+    public Long getIdRecurso() {
+        return idRecurso;
+    }
+    public void setIdRecurso(Long idRecurso) {
+        this.idRecurso = idRecurso;
+    }
+    public LocalDate getDataAgendamento() {
+        return dataAgendamento;
+    }
+    public void setDataAgendamento(LocalDate dataAgendamento) {
+        this.dataAgendamento = dataAgendamento;
+    }
+}


### PR DESCRIPTION
…entos

Cria o  para expor as funcionalidades da camada de serviço através de uma API REST.

- Adiciona endpoints para todas as operações CRUD (GET, GET por ID, POST, PUT e DELETE).
- Introduz  para desacoplar a camada da API do modelo de domínio nas requisições de criação, melhorando a segurança e a flexibilidade.
- As respostas dos endpoints utilizam os códigos de status HTTP apropriados (200 OK, 201 Created, 204 No Content).