### PR TITLE
Implementa autenticação e autorização com Spring Security

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,32 @@ A camada de Serviço (`@Service`) é a responsável por orquestrar a conversão 
 
 O `AgendamentoResponseDTO` é um exemplo claro de **orquestração de dados**: ele contém não só os detalhes do agendamento (dados do `common-domain`), mas também a informação se a data é um feriado e o nome desse feriado (dados do `external-api-client`), fornecendo uma resposta completa e enriquecida para o cliente final.
 
+
+## Segurança com Spring Security (Feature 4)
+
+A API foi protegida utilizando o framework Spring Security para garantir que apenas utilizadores autorizados possam aceder aos recursos. A implementação focou-se nos pilares de autenticação e autorização.
+
+### Autenticação
+
+* **Mecanismo**: A autenticação é realizada via **HTTP Basic Auth**. Todas as requisições à API devem incluir um cabeçalho `Authorization` com as credenciais do utilizador.
+* **Gestão de Utilizadores**: Para esta implementação, foram configurados dois utilizadores em memória com senhas codificadas utilizando BCrypt:
+    * `username`: **admin** | `password`: admin123 | `role`: ADMIN, USER
+    * `username`: **user** | `password`: password123 | `role`: USER
+
+### Autorização Baseada em Roles
+
+Foram definidas regras de acesso granulares para diferentes contextos da API, aplicando o **Princípio do Menor Privilégio**:
+
+* **Contexto de Moradores (`/api/moradores/**`)**:
+    * `GET` (Leitura): Acessível por `ADMIN` e `USER`.
+    * `POST`, `PUT`, `DELETE` (Escrita e Modificação): Acessível **apenas** por `ADMIN`.
+
+* **Contexto de Agendamentos (`/api/agendamentos/**`)**:
+    * `GET`, `POST`, `PUT` (Leitura e Gestão): Acessível por `ADMIN` e `USER`.
+    * `DELETE` (Cancelamento): Acessível **apenas** por `ADMIN`.
+
+* **Segurança por Padrão**: Qualquer outro endpoint que não corresponda às regras acima (ex: `/api/visitantes/**`) exige que o utilizador esteja, no mínimo, autenticado, garantindo que nenhum recurso fique exposto acidentalmente.
+
 ## Tecnologias Utilizadas
 
 * **Java 21** (ou superior)

--- a/main-application/pom.xml
+++ b/main-application/pom.xml
@@ -52,6 +52,11 @@
             <artifactId>lombok</artifactId>
             <optional>true</optional>
         </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/main-application/src/main/java/br/edu/infnet/matheusmacielapi/config/SecurityConfig.java
+++ b/main-application/src/main/java/br/edu/infnet/matheusmacielapi/config/SecurityConfig.java
@@ -1,0 +1,70 @@
+package br.edu.infnet.matheusmacielapi.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.provisioning.InMemoryUserDetailsManager;
+import org.springframework.security.web.SecurityFilterChain;
+
+import static org.springframework.security.config.Customizer.withDefaults;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .authorizeHttpRequests(authorizeRequests ->
+                        authorizeRequests
+                                // --- REGRAS PARA MORADORES ---
+                                .requestMatchers(HttpMethod.GET, "/api/moradores/**").hasAnyRole("USER", "ADMIN")
+                                .requestMatchers(HttpMethod.POST, "/api/moradores").hasRole("ADMIN")
+                                .requestMatchers(HttpMethod.PUT, "/api/moradores/**").hasRole("ADMIN")
+                                .requestMatchers(HttpMethod.DELETE, "/api/moradores/**").hasRole("ADMIN")
+
+                                // --- REGRAS PARA AGENDAMENTOS ---
+                                .requestMatchers(HttpMethod.GET, "/api/agendamentos/**").hasAnyRole("USER", "ADMIN")
+                                .requestMatchers(HttpMethod.POST, "/api/agendamentos").hasAnyRole("USER", "ADMIN")
+                                .requestMatchers(HttpMethod.PUT, "/api/agendamentos/**").hasAnyRole("USER", "ADMIN")
+                                .requestMatchers(HttpMethod.DELETE, "/api/agendamentos/**").hasRole("ADMIN")
+
+                                // --- REGRA PADRÃO ---
+                                .anyRequest().authenticated() // Qualquer outra requisição precisa de autenticação
+                )
+                .httpBasic(withDefaults())
+                .csrf(csrf -> csrf.disable());
+
+        return http.build();
+    }
+
+    @Bean
+    public InMemoryUserDetailsManager userDetailsService() {
+        PasswordEncoder encoder = passwordEncoder();
+
+        UserDetails user = User.builder()
+                .username("user")
+                .password(encoder.encode("password123"))
+                .roles("USER")
+                .build();
+
+        UserDetails admin = User.builder()
+                .username("admin")
+                .password(encoder.encode("admin123"))
+                .roles("ADMIN", "USER")
+                .build();
+
+        return new InMemoryUserDetailsManager(user, admin);
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}


### PR DESCRIPTION
Integra o Spring Security ao projeto para proteger a API, cumprindo os requisitos da Feature 4.

A implementação inclui:
- **Autenticação**: Ativada a autenticação HTTP Basic para todas as requisições. Foram criados dois utilizadores em memória (`admin` e `user`) com senhas devidamente codificadas utilizando BCrypt.

- **Autorização**: Aplicadas regras de autorização granulares baseadas em URL e método HTTP para dois contextos distintos: `/api/moradores` e `/api/agendamentos`. As permissões são segregadas por roles (`ADMIN`, `USER`), seguindo o Princípio do Menor Privilégio.

- **Segurança por Padrão**: Uma regra "catch-all" (`anyRequest().authenticated()`) foi configurada para garantir que todos os endpoints não especificados explicitamente exijam, no mínimo, autenticação.